### PR TITLE
Use Resolve-Path to make script work with relative...

### DIFF
--- a/Diff-Word.ps1
+++ b/Diff-Word.ps1
@@ -3,6 +3,9 @@ param(
     $ChangedFileName
 )
 
+$BaseFileName = Resolve-Path $BaseFileName | Select-Object -first 1 | Select -ExpandProperty "Path"
+$ChangedFileName = Resolve-Path $ChangedFileName | Select-Object -first 1 | Select -ExpandProperty "Path"
+
 $ErrorActionPreference = 'Stop'
 
 # Remove the readonly attribute because Word is unable to compare readonly
@@ -20,7 +23,7 @@ try {
 	$word = New-Object -ComObject Word.Application
 	$word.Visible = $true
 	$document = $word.Documents.Open($BaseFileName, $false, $false)
-	$document.Compare($ChangedFileName, [ref]"Comparison", [ref]$wdCompareTargetNew, [ref]$true, [ref]$true)
+	$document.Compare("$ChangedFileName", [ref]"Comparison", [ref]$wdCompareTargetNew, [ref]$true, [ref]$true)
 
 	$word.ActiveDocument.Saved = 1
 


### PR DESCRIPTION
paths. On my system anyway.

On my system, the tool only worked with absolute paths. This fixes the situation for me at least. Here is the error I was seeing:

![image](https://user-images.githubusercontent.com/244969/28393648-d1d97970-6c9c-11e7-80e9-96befbabfc58.png)
