### PR TITLE
Diff-Word: resolve file paths on start

### DIFF
--- a/Diff-Word.ps1
+++ b/Diff-Word.ps1
@@ -1,9 +1,16 @@
 param(
-    $BaseFileName,
-    $ChangedFileName
+    [string] $BaseFileName,
+    [string] $ChangedFileName
 )
 
 $ErrorActionPreference = 'Stop'
+
+function resolve($relativePath) {
+    (Resolve-Path $relativePath).Path
+}
+
+$BaseFileName = resolve $BaseFileName
+$ChangedFileName = resolve $ChangedFileName
 
 # Remove the readonly attribute because Word is unable to compare readonly
 # files:
@@ -17,16 +24,16 @@ $wdDoNotSaveChanges = 0
 $wdCompareTargetNew = 2
 
 try {
-	$word = New-Object -ComObject Word.Application
-	$word.Visible = $true
-	$document = $word.Documents.Open($BaseFileName, $false, $false)
-	$document.Compare($ChangedFileName, [ref]"Comparison", [ref]$wdCompareTargetNew, [ref]$true, [ref]$true)
+    $word = New-Object -ComObject Word.Application
+    $word.Visible = $true
+    $document = $word.Documents.Open($BaseFileName, $false, $false)
+    $document.Compare($ChangedFileName, [ref]"Comparison", [ref]$wdCompareTargetNew, [ref]$true, [ref]$true)
 
-	$word.ActiveDocument.Saved = 1
+    $word.ActiveDocument.Saved = 1
 
-	# Now close the document so only compare results window persists:
-	$document.Close([ref]$wdDoNotSaveChanges)
+    # Now close the document so only compare results window persists:
+    $document.Close([ref]$wdDoNotSaveChanges)
 } catch {
-	Add-Type -AssemblyName System.Windows.Forms
-	[System.Windows.Forms.MessageBox]::Show($_.Exception)
+    Add-Type -AssemblyName System.Windows.Forms
+    [System.Windows.Forms.MessageBox]::Show($_.Exception)
 }

--- a/License.md
+++ b/License.md
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 =====================
 
-Copyright (C) 2013–2016 by F. von Never
+Copyright (C) 2013–2017 by F. von Never
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
This should fix the issues with relative and PowerShell-only file paths (e.g. `~/file.docx`).

Closes #1.