### PR TITLE
Add GUI form for easy drag and drop operations

### DIFF
--- a/Gui-Diff-Word.ps1
+++ b/Gui-Diff-Word.ps1
@@ -1,0 +1,92 @@
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Windows.Forms
+
+$Form = New-Object System.Windows.Forms.Form
+$Form.ClientSize = New-Object System.Drawing.Point(600, 162)
+$Form.text = "Compare MS Word Documents"
+#Make a form topmost window - good for drag and drop operations
+$Form.TopMost = $true
+
+$olddoc = New-Object System.Windows.Forms.TextBox
+$olddoc.multiline = $true
+$olddoc.width = 582
+$olddoc.height = 50
+$olddoc.location = New-Object System.Drawing.Point(6, 8)
+$olddoc.AllowDrop = $true
+
+$newdoc = New-Object System.Windows.Forms.TextBox
+$newdoc.multiline = $true
+$newdoc.width = 582
+$newdoc.height = 50
+$newdoc.location = New-Object System.Drawing.Point(6, 65)
+$newdoc.AllowDrop = $true
+
+$cmpbtn = New-Object System.Windows.Forms.Button
+$cmpbtn.text = "Compare"
+$cmpbtn.width = 455
+$cmpbtn.height = 30
+$cmpbtn.location = New-Object System.Drawing.Point(6, 126)
+
+$clrbtn = New-Object System.Windows.Forms.Button
+$clrbtn.text = "Clear"
+$clrbtn.width = 120
+$clrbtn.height = 30
+$clrbtn.location = New-Object System.Drawing.Point(467, 126)
+
+$Form.controls.AddRange(@($olddoc, $newdoc, $cmpbtn, $clrbtn))
+
+$olddoc.Add_DragDrop( { DnD $this $_ })
+$olddoc.Add_DragOver( { DnO $this $_ })
+$newdoc.Add_DragDrop( { DnD $this $_ })
+$newdoc.Add_DragOver( { DnO $this $_ })
+$cmpbtn.Add_Click( { DoCompare $this $_ })
+$clrbtn.Add_Click( { ClearInputs $this $_ })
+
+function DnO ($evSource, $evtArgs) {
+    if ($evtArgs.Data.GetDataPresent([Windows.Forms.DataFormats]::FileDrop)) {
+        $evtArgs.Effect = [Windows.Forms.DragDropEffects]::Copy
+    }
+    else {
+        $evtArgs.Effect = [Windows.Forms.DragDropEffects]::None
+    }
+}
+function DnD ($evSource, $evtArgs) {
+    foreach ($filename in $evtArgs.Data.GetData([Windows.Forms.DataFormats]::FileDrop)) {
+        $evSource.text = $filename
+    }
+}
+function DoCompare ($evSource, $evArgs) {
+    $Form.TopMost = $false
+    $BaseFileName = $olddoc.text
+    $ChangedFileName = $newdoc.text
+    # Remove the readonly attribute because Word is unable to compare readonly
+    # files:
+    $baseFile = Get-ChildItem $BaseFileName
+    if ($baseFile.IsReadOnly) {
+        $baseFile.IsReadOnly = $false
+    }
+    # Constants
+    $wdDoNotSaveChanges = 0
+    $wdCompareTargetNew = 2
+    try {
+        $word = New-Object -ComObject Word.Application
+        $word.Visible = $true
+        $document = $word.Documents.Open($BaseFileName, $false, $false)
+        $document.Compare($ChangedFileName, [ref]"Comparison", [ref]$wdCompareTargetNew, [ref]$true, [ref]$true)
+
+        $word.ActiveDocument.Saved = 1
+
+        # Now close the document so only compare results window persists:
+        $document.Close([ref]$wdDoNotSaveChanges)
+    }
+    catch {
+        [System.Windows.Forms.MessageBox]::Show($_.Exception)
+    }
+}
+function ClearInputs ($evSource, $evtArgs) {
+    $olddoc.text = ""
+    $newdoc.text = ""
+    $Form.TopMost = $true
+}
+
+[void]$Form.ShowDialog()

--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,10 @@ Or via the batch file:
 $ diff-word.cmd oldfile.docx newfile.docx
 ```
 
+## Using GUI form
+
+To run the GUI form run file `start-gui.cmd`: it will open form that stays on top off all windows and you can drag files from Windows Explorer to two text fields (first for old document and second for revised document). When you click "Compare" button it will start Word application with chosen documents as in command line usage and this form will loose "stay on top of all windows" property. It will regain this property after button "Clear" is clicked.
+
 ## Using via Git Integration
 
 You can also use this tool with git, so that `git diff` will use Microsoft Word

--- a/start-gui.cmd
+++ b/start-gui.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -File "Gui-Diff-Word.ps1"


### PR DESCRIPTION
this repository was first result of google search "microsoft word command line compare" so I think it is good place to add some GUI utilities because some power users who needs to compare a lot of files from different folders will hate MS Word built-in Compare dialog. This change adds very simple Window.Forms GUI form with drag and drop support (no Browse... button).